### PR TITLE
fix missing include in catch.hpp

### DIFF
--- a/test/catch.hpp
+++ b/test/catch.hpp
@@ -376,6 +376,7 @@
 
 #include <sstream>
 #include <algorithm>
+#include <cstdint>
 
 namespace Catch {
 


### PR DESCRIPTION
uint64_t is used on line 7121, which causes a build failure if it isn`t inlcuded by any of the other headers